### PR TITLE
feat: merge MCP roots with CLI allowed dirs instead of replacing

### DIFF
--- a/cmd/mcp-file-tools/main.go
+++ b/cmd/mcp-file-tools/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/dimitar-grigorov/mcp-file-tools/filetoolsserver"
 	"github.com/dimitar-grigorov/mcp-file-tools/internal/security"
@@ -14,6 +16,20 @@ import (
 var version = "dev"
 
 func main() {
+	// Configure default logger to write to stderr (stdout is reserved for the
+	// MCP protocol on stdio). Level defaults to Info; set MCP_LOG_LEVEL=debug
+	// to surface slog.Debug output (e.g. normalized allowed directories).
+	level := slog.LevelInfo
+	switch strings.ToLower(os.Getenv("MCP_LOG_LEVEL")) {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
 	// Set version from build
 	filetoolsserver.Version = version
 
@@ -35,6 +51,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+		slog.Debug("normalized allowed directories", "dirs", normalized)
 	}
 
 	// Create MCP server with allowed directories (can be empty, directories can be added dynamically)

--- a/filetoolsserver/handler/allowed_dirs.go
+++ b/filetoolsserver/handler/allowed_dirs.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -10,6 +11,8 @@ import (
 func (h *Handler) HandleListAllowedDirectories(ctx context.Context, req *mcp.CallToolRequest, input ListAllowedDirectoriesInput) (*mcp.CallToolResult, ListAllowedDirectoriesOutput, error) {
 	dirs := h.GetAllowedDirectories()
 	output := ListAllowedDirectoriesOutput{Directories: dirs}
+
+	slog.Debug("list_allowed_directories response", "count", len(dirs), "dirs", dirs)
 
 	if len(dirs) == 0 {
 		output.Message = "No allowed directories configured. File operations will fail. " +

--- a/filetoolsserver/handler/handler.go
+++ b/filetoolsserver/handler/handler.go
@@ -17,6 +17,7 @@ const (
 // Handler handles all file tool operations
 type Handler struct {
 	config      *config.Config
+	cliDirs     []string // immutable baseline from CLI args; always allowed
 	allowedDirs []string
 	mu          sync.RWMutex
 }
@@ -36,8 +37,18 @@ func WithConfig(cfg *config.Config) Option {
 // NewHandler creates a new Handler with allowed directories and optional configuration.
 // If no config is provided via WithConfig, default configuration is used.
 func NewHandler(allowedDirs []string, opts ...Option) *Handler {
+	// Normalize the CLI baseline so dedup against (already-normalized) MCP roots
+	// is reliable regardless of how the caller passed the paths. Best-effort:
+	// fall back to the raw paths if normalization fails.
+	cliDirs, err := security.NormalizeAllowedDirs(allowedDirs)
+	if err != nil {
+		cliDirs = make([]string, len(allowedDirs))
+		copy(cliDirs, allowedDirs)
+	}
+
 	h := &Handler{
 		config:      config.Load(), // Load defaults from environment
+		cliDirs:     cliDirs,
 		allowedDirs: allowedDirs,
 	}
 
@@ -67,6 +78,30 @@ func (h *Handler) UpdateAllowedDirectories(newDirs []string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.allowedDirs = newDirs
+}
+
+// MergeAllowedDirectories sets allowed directories to the union of the immutable
+// CLI baseline and newDirs (deduped, baseline first). Used for the MCP Roots
+// protocol so client-provided roots augment, rather than replace, CLI args.
+func (h *Handler) MergeAllowedDirectories(newDirs []string) []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	seen := make(map[string]struct{}, len(h.cliDirs)+len(newDirs))
+	merged := make([]string, 0, len(h.cliDirs)+len(newDirs))
+	for _, dir := range append(append([]string{}, h.cliDirs...), newDirs...) {
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		merged = append(merged, dir)
+	}
+
+	h.allowedDirs = merged
+
+	result := make([]string, len(merged))
+	copy(result, merged)
+	return result
 }
 
 // validatePath validates a path against allowed directories

--- a/filetoolsserver/roots.go
+++ b/filetoolsserver/roots.go
@@ -3,6 +3,7 @@ package filetoolsserver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"runtime"
@@ -86,12 +87,10 @@ func updateAllowedDirectoriesFromRoots(h *handler.Handler, roots []*mcp.Root) {
 	}
 
 	if len(validatedDirs) > 0 {
-		h.UpdateAllowedDirectories(validatedDirs)
-		fmt.Fprintf(os.Stderr, "Updated allowed directories from MCP roots: %d directories\n", len(validatedDirs))
-		for _, dir := range validatedDirs {
-			fmt.Fprintf(os.Stderr, "  - %s\n", dir)
-		}
+		merged := h.MergeAllowedDirectories(validatedDirs)
+		slog.Debug("merged allowed directories from MCP roots",
+			"roots", validatedDirs, "merged", merged)
 	} else {
-		fmt.Fprintf(os.Stderr, "No valid root directories provided by client\n")
+		slog.Debug("no valid root directories provided by client")
 	}
 }

--- a/filetoolsserver/roots_test.go
+++ b/filetoolsserver/roots_test.go
@@ -121,44 +121,59 @@ func TestFileURIToPath(t *testing.T) {
 	}
 }
 
-func TestUpdateAllowedDirectoriesFromRoots_ReplacesExisting(t *testing.T) {
+func TestUpdateAllowedDirectoriesFromRoots_MergesWithCLIBaseline(t *testing.T) {
 	tempDir1 := t.TempDir()
 	tempDir2 := t.TempDir()
 
-	// Start with one directory
+	// Start with one CLI directory (baseline).
 	h := handler.NewHandler([]string{tempDir1})
 
-	// Verify initial state
 	initialDirs := h.GetAllowedDirectories()
 	if len(initialDirs) != 1 {
 		t.Fatalf("expected 1 initial directory, got %d", len(initialDirs))
 	}
-	initialDir := initialDirs[0]
 
-	// Update with different directory - should replace, not append
+	// Update with a different root - should augment the CLI baseline, not replace it.
 	roots := []*mcp.Root{
 		{URI: "file:///" + filepath.ToSlash(tempDir2)},
 	}
 
 	updateAllowedDirectoriesFromRoots(h, roots)
 
-	// After update, should have exactly 1 directory (replaced, not appended)
+	// After update, both the CLI baseline and the root should be present.
 	updatedDirs := h.GetAllowedDirectories()
-	if len(updatedDirs) != 1 {
-		t.Errorf("expected 1 directory after update (replacement), got %d", len(updatedDirs))
+	if len(updatedDirs) != 2 {
+		t.Fatalf("expected 2 directories after merge, got %d: %v", len(updatedDirs), updatedDirs)
 	}
 
-	// Verify the directory changed (it's not the same as initial)
-	if len(updatedDirs) > 0 {
-		updatedDir := updatedDirs[0]
+	want := map[string]bool{}
+	for _, d := range []string{tempDir1, tempDir2} {
+		resolved, _ := filepath.EvalSymlinks(d)
+		want[resolved] = true
+	}
+	for _, d := range updatedDirs {
+		resolved, _ := filepath.EvalSymlinks(d)
+		delete(want, resolved)
+	}
+	if len(want) != 0 {
+		t.Errorf("merged dirs missing expected entries: %v (got %v)", want, updatedDirs)
+	}
+}
 
-		// The updated directory should NOT be the same as the initial directory
-		// (Compare resolved paths to handle symlinks)
-		initialResolved, _ := filepath.EvalSymlinks(initialDir)
-		updatedResolved, _ := filepath.EvalSymlinks(updatedDir)
+func TestUpdateAllowedDirectoriesFromRoots_DedupsBaseline(t *testing.T) {
+	tempDir1 := t.TempDir()
 
-		if initialResolved == updatedResolved {
-			t.Errorf("directory was not replaced: still have %s", initialResolved)
-		}
+	h := handler.NewHandler([]string{tempDir1})
+
+	// Root identical to the CLI baseline must not produce a duplicate.
+	roots := []*mcp.Root{
+		{URI: "file:///" + filepath.ToSlash(tempDir1)},
+	}
+
+	updateAllowedDirectoriesFromRoots(h, roots)
+
+	updatedDirs := h.GetAllowedDirectories()
+	if len(updatedDirs) != 1 {
+		t.Errorf("expected 1 directory after dedup, got %d: %v", len(updatedDirs), updatedDirs)
 	}
 }


### PR DESCRIPTION
MCP roots received from the client previously overwrote the allowed directories passed via CLI args, silently dropping configured scope. Store the CLI args as an immutable baseline and union them with any client-provided roots (deduped) so both are always honored.

Also add MCP_LOG_LEVEL-gated debug logging (stderr) for normalized startup dirs, the list_allowed_directories response, and roots merges, to make allowed-directory resolution diagnosable.