### PR TITLE
chore: trim comments that only restated the name they document

### DIFF
--- a/filetoolsserver/handler/errors.go
+++ b/filetoolsserver/handler/errors.go
@@ -10,47 +10,28 @@ import "github.com/dimitar-grigorov/mcp-file-tools/v4/internal/errkind"
 
 // Input validation errors
 var (
-	// ErrPathRequired is returned when a required path parameter is empty.
-	ErrPathRequired = errkind.New(errkind.InvalidPath, "path is required and must be a non-empty string")
-
-	// ErrPatternRequired is returned when a required pattern parameter is empty.
-	ErrPatternRequired = errkind.New(errkind.InvalidInput, "pattern is required and must be a non-empty string")
-
-	// ErrPathMustBeDirectory is returned when a directory is expected but a file was provided.
+	ErrPathRequired        = errkind.New(errkind.InvalidPath, "path is required and must be a non-empty string")
+	ErrPatternRequired     = errkind.New(errkind.InvalidInput, "pattern is required and must be a non-empty string")
 	ErrPathMustBeDirectory = errkind.New(errkind.InvalidPath, "path must be a directory")
 )
 
 // Encoding errors
 var (
-	// ErrEncodingUnsupported is returned when an unsupported encoding is specified.
-	// Wrap this error to include the encoding name: fmt.Errorf("%w: %s", ErrEncodingUnsupported, name)
+	// Wrap to include the encoding name: fmt.Errorf("%w: %s", ErrEncodingUnsupported, name)
 	ErrEncodingUnsupported = errkind.New(errkind.Encoding, "unsupported encoding")
 
-	// ErrBOMEncodingConflict is returned when a file's BOM contradicts the requested encoding.
-	ErrBOMEncodingConflict = errkind.New(errkind.Encoding, "BOM conflicts with requested encoding")
-
-	// ErrBOMPolicyInvalid is returned for an unknown bom policy, or one the encoding cannot satisfy.
-	ErrBOMPolicyInvalid = errkind.New(errkind.InvalidInput, "invalid bom policy")
-
-	// ErrLineEndingPolicyInvalid is returned for an unknown lineEndings policy.
+	ErrBOMEncodingConflict     = errkind.New(errkind.Encoding, "BOM conflicts with requested encoding")
+	ErrBOMPolicyInvalid        = errkind.New(errkind.InvalidInput, "invalid bom policy")
 	ErrLineEndingPolicyInvalid = errkind.New(errkind.InvalidInput, "invalid lineEndings policy")
-
-	// ErrLineEndingActionInvalid is returned for an unknown manage_line_endings action.
 	ErrLineEndingActionInvalid = errkind.New(errkind.InvalidInput, `invalid action — valid: "detect", "convert"`)
-
-	// ErrLineEndingStyleRequired is returned when action="convert" arrives without a style.
 	ErrLineEndingStyleRequired = errkind.New(errkind.InvalidInput, `style is required for action="convert" — "lf" or "crlf"`)
 )
 
 // Edit operation errors
 var (
-	// ErrEditNoMatch is returned when old_text cannot be found in the file.
-	// Wrap this error to include context: fmt.Errorf("%w:\n%s", ErrEditNoMatch, oldText)
+	// Wrap to include context: fmt.Errorf("%w:\n%s", ErrEditNoMatch, oldText)
 	ErrEditNoMatch = errkind.New(errkind.InvalidInput, "could not find exact match for edit")
 
-	// ErrOldTextEmpty is returned when an edit operation has an empty old_text field.
-	ErrOldTextEmpty = errkind.New(errkind.InvalidInput, "edit old_text cannot be empty")
-
-	// ErrEditAmbiguous is returned when oldText matches more than once and replaceAll is unset.
+	ErrOldTextEmpty  = errkind.New(errkind.InvalidInput, "edit old_text cannot be empty")
 	ErrEditAmbiguous = errkind.New(errkind.InvalidInput, "oldText matches more than one place")
 )

--- a/filetoolsserver/handler/errors.go
+++ b/filetoolsserver/handler/errors.go
@@ -20,8 +20,11 @@ var (
 	// Wrap to include the encoding name: fmt.Errorf("%w: %s", ErrEncodingUnsupported, name)
 	ErrEncodingUnsupported = errkind.New(errkind.Encoding, "unsupported encoding")
 
-	ErrBOMEncodingConflict     = errkind.New(errkind.Encoding, "BOM conflicts with requested encoding")
-	ErrBOMPolicyInvalid        = errkind.New(errkind.InvalidInput, "invalid bom policy")
+	ErrBOMEncodingConflict = errkind.New(errkind.Encoding, "BOM conflicts with requested encoding")
+
+	// ErrBOMPolicyInvalid is also returned for a policy the encoding cannot satisfy.
+	ErrBOMPolicyInvalid = errkind.New(errkind.InvalidInput, "invalid bom policy")
+
 	ErrLineEndingPolicyInvalid = errkind.New(errkind.InvalidInput, "invalid lineEndings policy")
 	ErrLineEndingActionInvalid = errkind.New(errkind.InvalidInput, `invalid action — valid: "detect", "convert"`)
 	ErrLineEndingStyleRequired = errkind.New(errkind.InvalidInput, `style is required for action="convert" — "lf" or "crlf"`)
@@ -32,6 +35,8 @@ var (
 	// Wrap to include context: fmt.Errorf("%w:\n%s", ErrEditNoMatch, oldText)
 	ErrEditNoMatch = errkind.New(errkind.InvalidInput, "could not find exact match for edit")
 
-	ErrOldTextEmpty  = errkind.New(errkind.InvalidInput, "edit old_text cannot be empty")
+	ErrOldTextEmpty = errkind.New(errkind.InvalidInput, "edit old_text cannot be empty")
+
+	// ErrEditAmbiguous is returned when oldText matches more than once and replaceAll is unset.
 	ErrEditAmbiguous = errkind.New(errkind.InvalidInput, "oldText matches more than one place")
 )

--- a/filetoolsserver/handler/grep.go
+++ b/filetoolsserver/handler/grep.go
@@ -141,7 +141,6 @@ func resolveGrepEncoding(requested string) (string, string) {
 			"Call list_encodings for the supported names.", requested)
 }
 
-// compilePattern compiles the regex pattern with optional case sensitivity.
 func compilePattern(pattern string, caseSensitive *bool) (*regexp.Regexp, error) {
 	if caseSensitive != nil && !*caseSensitive {
 		pattern = "(?i)" + pattern
@@ -167,7 +166,6 @@ func namePatternError(patterns []string, caseSensitive *bool, err error) string 
 	return fmt.Sprintf("invalid regex pattern: %v", err)
 }
 
-// collectFiles gathers all files to search from the given paths.
 func (h *Handler) collectFiles(ctx context.Context, paths, includes, excludes []string, gitignore bool) []string {
 	var files []string
 	seen := make(map[string]bool)
@@ -445,7 +443,6 @@ func decodeWithFallback(data []byte, name, fallback string) (string, string) {
 	return decodeWithFallback(data, fallback, fallback)
 }
 
-// getContextBefore returns N lines before the given line index.
 func getContextBefore(lines []string, lineIdx, count int) []string {
 	start := max(lineIdx-count, 0)
 	if start >= lineIdx {
@@ -454,7 +451,6 @@ func getContextBefore(lines []string, lineIdx, count int) []string {
 	return lines[start:lineIdx]
 }
 
-// getContextAfter returns N lines after the given line index.
 func getContextAfter(lines []string, lineIdx, count int) []string {
 	end := min(lineIdx+count+1, len(lines))
 	if lineIdx+1 >= end {

--- a/filetoolsserver/handler/handler.go
+++ b/filetoolsserver/handler/handler.go
@@ -103,6 +103,7 @@ func NewHandler(allowedDirs []string, opts ...Option) *Handler {
 	return h
 }
 
+// GetAllowedDirectories returns a copy of the allowed directories.
 func (h *Handler) GetAllowedDirectories() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/filetoolsserver/handler/handler.go
+++ b/filetoolsserver/handler/handler.go
@@ -103,7 +103,6 @@ func NewHandler(allowedDirs []string, opts ...Option) *Handler {
 	return h
 }
 
-// GetAllowedDirectories returns a copy of the allowed directories.
 func (h *Handler) GetAllowedDirectories() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/internal/encoding/detect.go
+++ b/internal/encoding/detect.go
@@ -92,7 +92,7 @@ func BOMBytesFor(charset string) []byte {
 	}
 }
 
-// BOMSize returns 0 if charset has no BOM.
+// BOMSize returns the byte length of a BOM for the given charset, or 0 if unknown.
 func BOMSize(charset string) int {
 	b := BOMBytesFor(charset)
 	return len(b)

--- a/internal/encoding/detect.go
+++ b/internal/encoding/detect.go
@@ -33,7 +33,6 @@ const (
 	gbkConfidenceCap = 85 // cap when GBK is recovered from a Latin guess
 )
 
-// DetectionResult holds encoding detection result.
 type DetectionResult struct {
 	Charset    string
 	Confidence int
@@ -75,7 +74,7 @@ func DetectBOM(data []byte) (DetectionResult, bool) {
 	return DetectionResult{}, false
 }
 
-// BOMBytesFor returns the BOM byte sequence for a given encoding name, or nil if unsupported.
+// BOMBytesFor returns the BOM bytes for charset, or nil if unsupported.
 func BOMBytesFor(charset string) []byte {
 	switch strings.ToLower(charset) {
 	case "utf-8":
@@ -93,7 +92,7 @@ func BOMBytesFor(charset string) []byte {
 	}
 }
 
-// BOMSize returns the byte length of a BOM for the given charset, or 0 if unknown.
+// BOMSize returns 0 if charset has no BOM.
 func BOMSize(charset string) int {
 	b := BOMBytesFor(charset)
 	return len(b)
@@ -115,7 +114,6 @@ func DetectFromFile(path string, mode string) (DetectionResult, error) {
 	return detectFromReader(file, stat.Size(), mode)
 }
 
-// Detect detects encoding from a byte slice.
 func Detect(data []byte) DetectionResult {
 	if result, ok := DetectBOM(data); ok {
 		return result

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -19,16 +19,12 @@ import (
 )
 
 const (
-	// UpdateCheckURL is the GitHub API endpoint for latest release
 	UpdateCheckURL = "https://api.github.com/repos/dimitar-grigorov/mcp-file-tools/releases/latest"
+	RepoURL        = "https://github.com/dimitar-grigorov/mcp-file-tools"
 
-	// RepoURL is the GitHub repository URL
-	RepoURL = "https://github.com/dimitar-grigorov/mcp-file-tools"
-
-	// CheckInterval is the minimum time between API calls (respects GitHub rate limits)
+	// CheckInterval respects GitHub's rate limits.
 	CheckInterval = 30 * time.Minute
 
-	// httpTimeout is the timeout for HTTP requests to GitHub API
 	httpTimeout = 10 * time.Second
 )
 
@@ -105,7 +101,6 @@ func updateSteps(env install.Env) string {
 	return steps
 }
 
-// fetchLatestVersion queries the GitHub API for the latest release tag.
 func fetchLatestVersion(ctx context.Context) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, UpdateCheckURL, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Removed doc comments on sentinel errors, a couple of exported functions/types, and a few small helpers that only repeated what the identifier (or, for the errors, the error string) already said.
- Kept comments that explain *why* — e.g. the GitHub rate-limit rationale on `CheckInterval`, and the `wrap this error with context` usage notes.

## Test plan
- [x] Comment-only removals/shortenings; no logic changed.
- [ ] `make lint` / `make build` (not run locally — Go toolchain unavailable in this environment; changes are confined to comment lines inside otherwise untouched statements)