### PR TITLE
chore: drop comments that restate the code below them

### DIFF
--- a/filetoolsserver/handler/change_line_endings.go
+++ b/filetoolsserver/handler/change_line_endings.go
@@ -86,7 +86,6 @@ func (h *Handler) HandleChangeLineEndings(ctx context.Context, req *mcp.CallTool
 	info := DetectLineEndings([]byte(content))
 	originalStyle := info.Style
 
-	// Already in target style — no-op
 	if originalStyle == style || originalStyle == LineEndingNone {
 		return &mcp.CallToolResult{}, ChangeLineEndingsOutput{
 			Message:       fmt.Sprintf("File already uses %s line endings, no changes needed", style),
@@ -96,7 +95,6 @@ func (h *Handler) HandleChangeLineEndings(ctx context.Context, req *mcp.CallTool
 		}, nil
 	}
 
-	// Count lines that will change
 	var linesChanged int
 	if style == LineEndingLF {
 		linesChanged = info.CRLFCount

--- a/filetoolsserver/handler/encoding_test.go
+++ b/filetoolsserver/handler/encoding_test.go
@@ -23,17 +23,14 @@ func TestHandleListEncodings(t *testing.T) {
 		t.Errorf("expected success, got error: %v", result.Content)
 	}
 
-	// Check encodings list
 	if len(output.Encodings) == 0 {
 		t.Fatal("expected encodings list, got empty")
 	}
 
-	// Check minimum expected number of encodings (we now support 20)
 	if len(output.Encodings) < 15 {
 		t.Errorf("expected at least 15 encodings, got %d", len(output.Encodings))
 	}
 
-	// Helper to check if encoding exists
 	hasEncoding := func(name string) bool {
 		for _, enc := range output.Encodings {
 			if enc.Name == name {

--- a/filetoolsserver/handler/fileinfo_windows.go
+++ b/filetoolsserver/handler/fileinfo_windows.go
@@ -20,7 +20,6 @@ func getFileTimes(stat os.FileInfo) (created, accessed, modified time.Time) {
 		created = time.Unix(0, sys.CreationTime.Nanoseconds())
 		accessed = time.Unix(0, sys.LastAccessTime.Nanoseconds())
 	} else {
-		// Fallback if syscall data is not available
 		created = modified
 		accessed = modified
 	}

--- a/filetoolsserver/server.go
+++ b/filetoolsserver/server.go
@@ -80,7 +80,6 @@ func NewServer(allowedDirs []string, logger *slog.Logger, cfg *config.Config) *m
 	// Guided workflows, surfaced by clients as user commands.
 	registerPrompts(server)
 
-	// Register all tools using the new AddTool API with annotations
 	// All handlers are wrapped with recovery middleware (and logging if logger is provided)
 
 	// Orient: find files and directories

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,6 @@ func Load() *Config {
 		MemoryThreshold: DefaultMaxSize,
 	}
 
-	// Load default encoding from environment
 	if enc := os.Getenv(EnvDefaultEncoding); enc != "" {
 		if _, ok := encoding.Get(enc); ok {
 			cfg.DefaultEncoding = enc
@@ -60,7 +59,6 @@ func Load() *Config {
 		}
 	}
 
-	// Load default line endings from environment
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvDefaultLineEnding))) {
 	case "crlf":
 		cfg.DefaultLineEndings = "crlf"
@@ -71,10 +69,8 @@ func Load() *Config {
 		slog.Warn("invalid MCP_DEFAULT_LINE_ENDINGS, ignoring", "value", os.Getenv(EnvDefaultLineEnding))
 	}
 
-	// Load detection candidates from environment
 	cfg.DetectionCandidates = parseDetectionCandidates(os.Getenv(EnvDetectionCandidates))
 
-	// Load memory threshold from environment
 	if sizeStr := os.Getenv(EnvMemoryThreshold); sizeStr != "" {
 		if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil && size > 0 {
 			cfg.MemoryThreshold = size

--- a/internal/encoding/registry_test.go
+++ b/internal/encoding/registry_test.go
@@ -116,7 +116,6 @@ func TestListEncodings(t *testing.T) {
 		}
 	}
 
-	// Verify we have the expected number of encodings (25)
 	if len(items) != 25 {
 		t.Errorf("ListEncodings() returned %d items, want 25", len(items))
 	}


### PR DESCRIPTION
Twelve comments removed, each one a restatement of the line directly beneath it. No code changed — `go build ./...`, `go test ./...`, `go vet ./...` and `gofmt -l .` are all clean.

### What went, and why

| Location | Comment | Why it was dead |
|---|---|---|
| `internal/config/config.go:53` | `// Load default encoding from environment` | Sits on `os.Getenv(EnvDefaultEncoding)` — the call says it. |
| `internal/config/config.go:63` | `// Load default line endings from environment` | Sits on the `switch` over `os.Getenv(EnvDefaultLineEnding)`. |
| `internal/config/config.go:74` | `// Load detection candidates from environment` | Sits on `parseDetectionCandidates(os.Getenv(EnvDetectionCandidates))`. |
| `internal/config/config.go:77` | `// Load memory threshold from environment` | Sits on `os.Getenv(EnvMemoryThreshold)`. All four label a `Getenv` with the name of the env var already in the call. |
| `filetoolsserver/server.go:83` | `// Register all tools using the new AddTool API with annotations` | The 20-odd `mcp.AddTool(server, &mcp.Tool{... Annotations: ...})` calls below say this, and "the new API" hasn't been new for a while. The line under it — handlers are wrapped with recovery middleware — is kept: `handler.Wrap` doesn't say that at the call site. |
| `filetoolsserver/handler/change_line_endings.go:89` | `// Already in target style — no-op` | The guard is `originalStyle == style`, returning `LinesChanged: 0` and the message "no changes needed". |
| `filetoolsserver/handler/change_line_endings.go:99` | `// Count lines that will change` | Sits on `var linesChanged int`. |
| `filetoolsserver/handler/fileinfo_windows.go:23` | `// Fallback if syscall data is not available` | It's the `else` of `if sys != nil`. Note the Linux and Darwin siblings keep theirs — those explain *why* ctime substitutes for a missing birthtime, which the code can't show. |
| `internal/encoding/registry_test.go:119` | `// Verify we have the expected number of encodings (25)` | Restates `if len(items) != 25 { ... want 25 }`, and put the count in a third place that has to be updated whenever the registry grows. |
| `filetoolsserver/handler/encoding_test.go:26` | `// Check encodings list` | Sits on `if len(output.Encodings) == 0`. |
| `filetoolsserver/handler/encoding_test.go:31` | `// Check minimum expected number of encodings (we now support 20)` | Restates `len(output.Encodings) < 15`, and the parenthetical had gone stale — the registry is at 24. |
| `filetoolsserver/handler/encoding_test.go:36` | `// Helper to check if encoding exists` | Sits on `hasEncoding := func(name string) bool`. |

### What was deliberately left

- **All of `.github/workflows/`.** Every comment there is load-bearing: the `# v7.0.1`-style trailers next to pinned SHAs are what make the pins readable and what Dependabot updates, the `permissions:` trailers justify each grant, and the block comments in `publish-registry.yml` and `release.yml` record the GITHUB_TOKEN trigger-suppression gotcha that silently skipped two releases.
- **Section headers** — `// Read`, `// Modify`, `// File management` in `server.go`; `// Cyrillic`, `// Greek` in `registry.go`; the groupings in `test_server.go`. They navigate a long list rather than describe one line.
- **Doc comments on exported identifiers** (`internal/security/errors.go`, `internal/updater/updater.go`, the `config.go` field comments) — godoc convention, and several add detail the identifier doesn't.
- **The `// Check for Windows-1251 (Cyrillic)` family** in `encoding_test.go` — the parenthetical names the script, which the charset ID alone doesn't.
- The large clusters of `// Create source file` / `// Verify destination exists` in `move_file_test.go`, `permissions_test.go` and friends. They are redundant, but sweeping them would have meant a 50-file diff for no reader benefit; happy to do that separately if you want it.

### Relationship to #21

#21 is an independent sweep with the same goal, opened separately. The two do not overlap — it touches `errors.go`, `grep.go`, `handler.go`, `detect.go` and `updater.go`; this one touches six other files — so they merge in either order without conflict.

Worth a reviewer's eye, though: #21 and this PR draw the line in different places. #21 removes godoc comments from exported identifiers (`ErrPathRequired`, `DetectionResult`, `Detect`, `UpdateCheckURL`, `GetAllowedDirectories`) and regroups them into aligned var blocks. This PR deliberately kept that category, on the grounds that godoc renders them and the convention expects them. Both readings are defensible, but they should be settled the same way in both PRs rather than landing inconsistently.
