### PR TITLE
fix(edit_file): resolve mixed/none line-ending style before write-back

### DIFF
--- a/filetoolsserver/handler/edit_file.go
+++ b/filetoolsserver/handler/edit_file.go
@@ -70,6 +70,14 @@ func (h *Handler) HandleEditFile(ctx context.Context, req *mcp.CallToolRequest, 
 	if lineEndings.Style == LineEndingMixed {
 		slog.Warn("file has mixed line endings", "path", input.Path, "crlf", lineEndings.CRLFCount, "lf", lineEndings.LFCount)
 	}
+	// Resolve to a concrete crlf/lf target before writing back. ConvertLineEndings
+	// only special-cases "crlf" as a target; passing "mixed" or "none" straight
+	// through silently collapsed every line ending in the file to LF. Mixed
+	// repairs to the dominant style, same as write_file's resolveLineEndingStyle.
+	targetLineEndingStyle := dominantLineEnding(lineEndings)
+	if targetLineEndingStyle == "" {
+		targetLineEndingStyle = h.config.DefaultLineEndings
+	}
 
 	content = ConvertLineEndings(content, LineEndingLF)
 	var modifiedContent string
@@ -89,7 +97,7 @@ func (h *Handler) HandleEditFile(ctx context.Context, req *mcp.CallToolRequest, 
 		if r := cancelled(ctx); r != nil {
 			return r, EditFileOutput{}, nil
 		}
-		if err := atomicWriteFileWithEncoding(v.Path, modifiedContent, encodingName, lineEndings.Style, originalMode); err != nil {
+		if err := atomicWriteFileWithEncoding(v.Path, modifiedContent, encodingName, targetLineEndingStyle, originalMode); err != nil {
 			return errorResult(fmt.Sprintf("failed to write file: %v", err)), EditFileOutput{}, nil
 		}
 	}

--- a/filetoolsserver/handler/edit_file_line_endings_test.go
+++ b/filetoolsserver/handler/edit_file_line_endings_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Dimitar Grigorov
+
+package handler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A CRLF file that also contains one bare LF (e.g. embedded in a multi-line
+// string literal, far from the edited line) must stay CRLF after edit_file
+// touches an unrelated line. Regression test for the bug where edit_file
+// passed DetectLineEndings' raw "mixed"/"none" Style straight into
+// ConvertLineEndings, which only special-cases "crlf" — every other target,
+// including "mixed", silently fell through to the LF branch and stripped
+// every CRLF in the file on write-back.
+func TestHandleEditFile_MixedLineEndingsRepairToDominantStyle(t *testing.T) {
+	tempDir := t.TempDir()
+	h := NewHandler([]string{tempDir})
+
+	testFile := filepath.Join(tempDir, "mixed.txt")
+	// 3 CRLF-terminated lines, one bare LF embedded inside a "string literal"
+	// on an unrelated line: file-wide style is CRLF-dominant "mixed", not pure CRLF.
+	original := "line1\r\nliteral := 'a' + Chr(10) + 'b'\nline3\r\nMARKER_OLD\r\n"
+	if err := os.WriteFile(testFile, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := EditFileInput{
+		Path:  testFile,
+		Edits: []EditOperation{{OldText: "MARKER_OLD", NewText: "MARKER_NEW"}},
+	}
+
+	result, _, err := h.HandleEditFile(context.Background(), nil, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+
+	got, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "line1\r\nliteral := 'a' + Chr(10) + 'b'\r\nline3\r\nMARKER_NEW\r\n"
+	if string(got) != want {
+		t.Errorf("edit_file corrupted line endings on a mixed-but-CRLF-dominant file\ngot:  %q\nwant: %q", got, want)
+	}
+
+	crlf := strings.Count(string(got), "\r\n")
+	if crlf != 4 {
+		t.Errorf("expected 4 CRLF line endings preserved, got %d (content: %q)", crlf, got)
+	}
+}
+
+// A file that's LF-dominant (more bare LF than CRLF) should repair to LF,
+// not CRLF — dominantLineEnding picks the more common style either way.
+func TestHandleEditFile_MixedLineEndingsRepairToLFWhenDominant(t *testing.T) {
+	tempDir := t.TempDir()
+	h := NewHandler([]string{tempDir})
+
+	testFile := filepath.Join(tempDir, "mixed_lf_dominant.txt")
+	original := "line1\nline2\nline3\r\nMARKER_OLD\n"
+	if err := os.WriteFile(testFile, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := EditFileInput{
+		Path:  testFile,
+		Edits: []EditOperation{{OldText: "MARKER_OLD", NewText: "MARKER_NEW"}},
+	}
+
+	result, _, err := h.HandleEditFile(context.Background(), nil, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+
+	got, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "line1\nline2\nline3\nMARKER_NEW\n"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
fixes #24 
edit_file computed the file's line-ending style with DetectLineEndings (which can return crlf, lf, mixed, or none) and passed that value straight through as the write-back target. ConvertLineEndings only special-cases a target of crlf; every other value, including mixed, fell through to the LF branch. Since edit_file always normalizes its working copy to LF before applying edits, that write was always a no-op on an already-LF string, so a mixed target silently produced pure-LF output regardless of how CRLF-dominant the original file was.

A file only needs one bare \n anywhere in it - e.g. an embedded Chr(10) inside a message/report string literal, unrelated to the line actually being edited - to be classified mixed and lose every CRLF in the file on the next edit_file call.

write_file does not have this bug: it already resolves through resolveLineEndingStyle -> dominantLineEnding, which collapses mixed to whichever style is more common before it reaches ConvertLineEndings. edit_file just never called that helper.

Route lineEndings.Style through the existing dominantLineEnding() helper before it reaches atomicWriteFileWithEncoding, falling back to the configured default for a brand-new/no-newline file. No behavior change for the common case (pure CRLF or pure LF files).

<!--
Keep this as short as you like. One sentence is a valid PR description.
Nothing below is mandatory — delete what doesn't apply.
-->

**What this changes:**

**If it's a bug fix:** which file/encoding triggered it, and what the tool did instead of what you expected.

---

No CLA, no checklist to satisfy. `make test` and `make lint` passing is enough, and tests for new behaviour are welcome but not required — say so if you skipped them.
